### PR TITLE
0026 - Fixed Animation Issues and Rolling Collision

### DIFF
--- a/Project2.gmx/objects/obj_debugtext.object.gmx
+++ b/Project2.gmx/objects/obj_debugtext.object.gmx
@@ -93,6 +93,8 @@ if(instance_exists(obj_race_start))
     draw_text(10, 120, "race time"+string_format(global.race_timer, 2, 2)); 
     
 draw_text(10, 156, "dash_count: "+string_format(obj_player.dash_count, 2, 2));
+
+draw_text(10, 168, "roll, slide: "+string_format(obj_player.is_rolling, 1, 0)+","+string_format(obj_player.is_sliding, 1, 0)); 
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_player.object.gmx
+++ b/Project2.gmx/objects/obj_player.object.gmx
@@ -27,30 +27,58 @@
             <kind>1</kind>
             <string>/// Initialize the player
 
-maxspd = 8;
-minspd = 0;
-jumpheight = 8;
-jumppeak = 0;  
-hspd = 0;
-vspd = 0;
-xrem = 0;
-yrem = 0;
-acc = .5;
-grav = .30;
+// Movement variables
+    maxspd = 8;
+    minspd = 0;
+    jumpheight = 8;
+    jumppeak = 0;
+    hspd = 0;
+    vspd = 0;
+    xrem = 0;
+    yrem = 0;
+    acc = .5;
+    grav = .30;
+    is_sliding = 0;
+    is_rolling = 0;
 
-dash_count = 0;
-can_dash = false;
-dash_speed = 15;
-dash_frames_v = 0;
-dash_frames_h = 0;
-dashed = false;
+// Dash variables
+    dash_count = 0;
+    can_dash = false;
+    dash_speed = 15;
+    dash_frames_v = 0;
+    dash_frames_h = 0;
+    dashed = false;
 
-is_rolling = 0;
-is_sliding = 0; 
+// Input variables
+    right = false;
+    left = false;
+    right_pressed = false;
+    left_pressed = false; 
+    up = false; 
+    down = false;
+    up_held = false; 
+    down_held = false;
+    sprint = false;
+    dash = false;
+    gp_id = 0;
+    threshold = .9;
+
+// Gamepad input variables
+    stick_left_held = false;
+    stick_left_pressed = false;
+    stick_left_released = false;
+    stick_right_held = false;
+    stick_right_pressed = false;
+    stick_right_released = false;
+    stick_up_held = false;
+    stick_up_pressed = false;
+    stick_up_released = false;
+    stick_down_held = false;
+    stick_down_pressed = false;
+    stick_down_released = false;
+    controller_alarm = 1;
 
 state = scr_player_move_state;
-
-scr_get_input();
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_player.object.gmx
+++ b/Project2.gmx/objects/obj_player.object.gmx
@@ -244,7 +244,9 @@ script_execute(state);
     //If the rolling animation has not finished and the speed is 0, set the speed to 3 times the direction of the previous movement. 
     //Lower max speed to 3 when rolling.
     else if(sprite_index == spr_player_roll &amp;&amp; hspd == 0 &amp;&amp; direction_horizontal == 0 &amp;&amp; image_index &lt;= image_number-1){
-        if(!place_meeting(x+4, y, obj_solid) &amp;&amp; !place_meeting(x+3, y, obj_solid) &amp;&amp; !place_meeting(x+2, y, obj_solid) &amp;&amp; !place_meeting(x+1, y, obj_solid)){ x += 3 * sign(image_xscale) * global.delta; }
+        if(!place_meeting(x+(3*sign(image_xscale)), y, obj_solid) &amp;&amp; !place_meeting(x+(2*sign(image_xscale)), y, obj_solid) &amp;&amp; !place_meeting(x+(1*sign(image_xscale)), y, obj_solid)){ 
+            x += 3 * sign(image_xscale) * global.delta; 
+        }
         is_rolling = 1;
         maxspd = 3; 
     }

--- a/Project2.gmx/objects/obj_player.object.gmx
+++ b/Project2.gmx/objects/obj_player.object.gmx
@@ -45,6 +45,9 @@ dash_frames_v = 0;
 dash_frames_h = 0;
 dashed = false;
 
+is_rolling = 0;
+is_sliding = 0; 
+
 state = scr_player_move_state;
 
 scr_get_input();
@@ -99,17 +102,23 @@ script_execute(state);
 //Horizontal animations if no vertical speed. 
     
     //Switches to idle if hspd and vspd are 0 and we aren't finishing the falling animation.
+    //Reset the max speed to normal, in case the player was rolling. 
     if(hspd == 0 &amp;&amp; vspd == 0 &amp;&amp; sprite_index != spr_player_fall &amp;&amp; sprite_index != spr_player_slide 
        &amp;&amp; sprite_index != spr_player_crouch &amp;&amp; (sprite_index != spr_player_slide_to_crouch &amp;&amp; !down_held &amp;&amp; !down)){ 
         sprite_index = spr_player_idle; 
         maxspd = 8; 
         image_index = 0; 
+        is_rolling = 0;
+        is_sliding = 0;
     }
     //Switches to running if we have any hspd but aren't jumping/falling.
+    //Reset max speed to normal, in case the player was previously rolling.
     else if(hspd != 0 &amp;&amp; vspd == 0 &amp;&amp; sprite_index != spr_player_slide &amp;&amp; (!down &amp;&amp; !down_held &amp;&amp; sprite_index != spr_player_roll)){
         sprite_index = spr_fahad_player_test_1; 
         maxspd = 8;   
         image_speed = .13*abs(hspd)/4 * (delta_time)/(1/60*1000000); //animation speed is a factor of our speed. 
+        is_rolling = 0;
+        is_sliding = 0;
     }
     
 //Jumping and falling animation based on previous animation conditions. 
@@ -148,6 +157,7 @@ script_execute(state);
         sprite_index = spr_player_slide;
         image_index = 0;
         image_speed = (delta_time)/(1/15*1000000);
+        is_sliding = 1;
     }
     //Stops the sliding animation on the slide 
     if(sprite_index == spr_player_slide &amp;&amp; image_index &gt;= 3 &amp;&amp; image_index &lt; 4){
@@ -163,12 +173,13 @@ script_execute(state);
     else if(!down &amp;&amp; !down_held &amp;&amp; sprite_index == spr_player_slide &amp;&amp; image_index &gt; image_number-1){
         sprite_index = spr_player_idle;  
         image_index = 0; 
+        is_sliding = 0;
     }
     
 //Crouching Animation
 
     //Switches to the crouching animation if the player presses down, isn't moving, and hasn't already been switched.
-    if(down &amp;&amp; place_meeting(x, y+16, obj_solid) &amp;&amp; hspd == 0 &amp;&amp; sprite_index != spr_player_crouch){
+    if(down &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; hspd == 0 &amp;&amp; sprite_index != spr_player_crouch){
         sprite_index = spr_player_crouch; 
         image_index = 0;
         image_speed = (delta_time)/(1/9*1000000);
@@ -176,7 +187,7 @@ script_execute(state);
     //Stops the crouching animation on the squat.
     else if(sprite_index == spr_player_crouch &amp;&amp; image_index &gt; 2 &amp;&amp; image_index &lt; 3){
         image_index = 2;
-        image_speed = 0; 
+        image_speed = 0;
     }
     //Reverse the crouching animation if the player lets go of the down key. 
     else if(!down &amp;&amp; !down_held &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_crouch &amp;&amp; image_index &lt;= (image_number/2)){
@@ -191,36 +202,51 @@ script_execute(state);
     
 //Slide to Crouch Animation  
 
+    //Switches the slide animation to the slide-to-crouch animation if hspd is 0.
     if((down || down_held) &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_slide &amp;&amp; image_index == 3){
         sprite_index = spr_player_slide_to_crouch;
         image_index = 0;  
         image_speed = (delta_time)/(1/9*1000000); 
+        is_sliding = 0;
     }
+    //Switches to the crouch animation once the slide-to-crouch animation finishes. 
     else if((down || down_held) &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_slide_to_crouch &amp;&amp; image_index &gt; image_number-1){
         image_speed = 0; 
         sprite_index = spr_player_crouch;
         image_index = 2;  
+        is_sliding = 0;
     }
      
 //Rolling Animation
 
-    if((down || down_held)&amp;&amp; place_meeting(x, y+16, obj_solid) &amp;&amp; hspd != 0 &amp;&amp; sprite_index == spr_player_crouch){
+    //Switches to the rolling animation if down is being pressed and there is any horizontal speed and the player is in the crouching animation. 
+    //Lower max speed to 3 when rolling.
+    if((down || down_held) &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; hspd != 0 &amp;&amp; sprite_index == spr_player_crouch){
         sprite_index = spr_player_roll;
         image_index = 0;
         image_speed = abs(hspd) * (delta_time)/(1/30*1000000); 
         maxspd = 3; 
+        is_rolling = 1; 
     }
+    //Switches to the crouching animation if the speed of the horizontal movement is 0.
+    //Reset max speed to normal.  
     else if(sprite_index == spr_player_roll &amp;&amp; hspd == 0 &amp;&amp; image_index &gt; image_number-1){
         sprite_index = spr_player_crouch; 
         image_index = 2;
         image_speed = 0; 
         maxspd = 8;
+        is_rolling = 0; 
     }
+    //If the rolling animation has not finished and the speed is 0, set the speed to 3 times the direction of the previous movement. 
+    //Lower max speed to 3 when rolling.
     else if(sprite_index == spr_player_roll &amp;&amp; hspd == 0 &amp;&amp; image_index &lt;= image_number-1){
-        hspd += 3 * sign(image_xscale); 
+        if(!place_meeting(x+1, y, obj_solid)){ x += 3 * sign(image_xscale) * global.delta; }
         maxspd = 3; 
+        is_rolling = 1;
     }
     
+
+
     
     
 </string>

--- a/Project2.gmx/objects/obj_player.object.gmx
+++ b/Project2.gmx/objects/obj_player.object.gmx
@@ -98,7 +98,6 @@ script_execute(state);
           <argument>
             <kind>1</kind>
             <string>///Animations
-
 //Horizontal animations if no vertical speed. 
     
     //Switches to idle if hspd and vspd are 0 and we aren't finishing the falling animation.
@@ -109,11 +108,11 @@ script_execute(state);
         maxspd = 8; 
         image_index = 0; 
         is_rolling = 0;
-        is_sliding = 0;
+        is_sliding = 0; 
     }
     //Switches to running if we have any hspd but aren't jumping/falling.
     //Reset max speed to normal, in case the player was previously rolling.
-    else if(hspd != 0 &amp;&amp; vspd == 0 &amp;&amp; sprite_index != spr_player_slide &amp;&amp; (!down &amp;&amp; !down_held &amp;&amp; sprite_index != spr_player_roll)){
+    else if(hspd != 0 &amp;&amp; vspd == 0 &amp;&amp; sprite_index != spr_player_slide &amp;&amp; sprite_index != spr_player_crouch &amp;&amp; sprite_index != spr_player_roll){
         sprite_index = spr_fahad_player_test_1; 
         maxspd = 8;   
         image_speed = .13*abs(hspd)/4 * (delta_time)/(1/60*1000000); //animation speed is a factor of our speed. 
@@ -142,12 +141,14 @@ script_execute(state);
     }
     //Starts playing the falling animation once the player hits the ground. 
     else if(vspd == 0 &amp;&amp; sprite_index == spr_player_fall &amp;&amp; image_index == 0){
-        image_speed = (delta_time)/(1/15*1000000);
+        image_speed = (delta_time)/(1/15*1000000); 
     }
     //Switches back to idle once the falling animation finishes. 
     else if(floor(vspd) == 0 &amp;&amp; sprite_index == spr_player_fall &amp;&amp; image_index &gt; image_number-1){
         sprite_index = spr_player_idle; 
         image_index = 0;
+        audio_play_sound(snd_gong, 1, 0);
+        audio_sound_gain(snd_gong, .3, 0); 
     }
     
 //Sliding Animations
@@ -173,60 +174,63 @@ script_execute(state);
     else if(!down &amp;&amp; !down_held &amp;&amp; sprite_index == spr_player_slide &amp;&amp; image_index &gt; image_number-1){
         sprite_index = spr_player_idle;  
         image_index = 0; 
-        is_sliding = 0;
+        is_sliding = 0; 
     }
     
 //Crouching Animation
 
     //Switches to the crouching animation if the player presses down, isn't moving, and hasn't already been switched.
-    if(down &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; hspd == 0 &amp;&amp; sprite_index != spr_player_crouch){
+    if((down || down_held) &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; hspd == 0 &amp;&amp; sprite_index != spr_player_crouch &amp;&amp; sprite_index != spr_player_roll ){
         sprite_index = spr_player_crouch; 
         image_index = 0;
-        image_speed = (delta_time)/(1/9*1000000);
+        image_speed = (delta_time)/(1/9*1000000); 
     }
     //Stops the crouching animation on the squat.
-    else if(sprite_index == spr_player_crouch &amp;&amp; image_index &gt; 2 &amp;&amp; image_index &lt; 3){
+    else if(sprite_index == spr_player_crouch &amp;&amp; image_index &gt; 2 &amp;&amp; image_index &lt; 3 &amp;&amp; is_rolling == 0){
         image_index = 2;
-        image_speed = 0;
+        image_speed = 0; 
     }
     //Reverse the crouching animation if the player lets go of the down key. 
-    else if(!down &amp;&amp; !down_held &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_crouch &amp;&amp; image_index &lt;= (image_number/2)){
+    else if(!down &amp;&amp; !down_held &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_crouch &amp;&amp; image_index &lt;= (image_number/2) ){
         image_index = image_number-1 - image_index; 
-        image_speed = (delta_time)/(1/15*1000000);
+        image_speed = (delta_time)/(1/15*1000000); 
     }
     //Switches to the idle animation if the down key is not being pressed and the crouching animation has finished.
-    else if(!down &amp;&amp; !down_held &amp;&amp; sprite_index == spr_player_crouch &amp;&amp; image_index &gt; image_number-1){
+    else if(!down &amp;&amp; !down_held &amp;&amp; sprite_index == spr_player_crouch &amp;&amp; image_index &gt; image_number-1 ){
         sprite_index = spr_player_idle; 
-        image_index = 0; 
+        image_index = 0;   
     }
     
 //Slide to Crouch Animation  
 
-    //Switches the slide animation to the slide-to-crouch animation if hspd is 0.
+    //Switches the slide animation to the slide-to-crouch animation if hspd is 0 and the player is holdling/pressing down.
     if((down || down_held) &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_slide &amp;&amp; image_index == 3){
         sprite_index = spr_player_slide_to_crouch;
         image_index = 0;  
         image_speed = (delta_time)/(1/9*1000000); 
-        is_sliding = 0;
+        is_sliding = 0; 
     }
     //Switches to the crouch animation once the slide-to-crouch animation finishes. 
     else if((down || down_held) &amp;&amp; hspd == 0 &amp;&amp; sprite_index == spr_player_slide_to_crouch &amp;&amp; image_index &gt; image_number-1){
         image_speed = 0; 
         sprite_index = spr_player_crouch;
-        image_index = 2;  
-        is_sliding = 0;
+        image_index = 2;   
+        is_sliding = 0; 
+        
     }
      
 //Rolling Animation
 
     //Switches to the rolling animation if down is being pressed and there is any horizontal speed and the player is in the crouching animation. 
     //Lower max speed to 3 when rolling.
-    if((down || down_held) &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; hspd != 0 &amp;&amp; sprite_index == spr_player_crouch){
+    if((down || down_held) &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; (direction_horizontal != 0 || hspd != 0) 
+       &amp;&amp; (sprite_index == spr_player_crouch || sprite_index == spr_player_slide_to_crouch)){
         sprite_index = spr_player_roll;
         image_index = 0;
-        image_speed = abs(hspd) * (delta_time)/(1/30*1000000); 
-        maxspd = 3; 
+        image_speed = (delta_time)/(1/20*1000000); 
+        is_sliding = 0;
         is_rolling = 1; 
+        maxspd = 3;
     }
     //Switches to the crouching animation if the speed of the horizontal movement is 0.
     //Reset max speed to normal.  
@@ -234,17 +238,16 @@ script_execute(state);
         sprite_index = spr_player_crouch; 
         image_index = 2;
         image_speed = 0; 
-        maxspd = 8;
         is_rolling = 0; 
+        maxspd = 8; 
     }
     //If the rolling animation has not finished and the speed is 0, set the speed to 3 times the direction of the previous movement. 
     //Lower max speed to 3 when rolling.
-    else if(sprite_index == spr_player_roll &amp;&amp; hspd == 0 &amp;&amp; image_index &lt;= image_number-1){
-        if(!place_meeting(x+1, y, obj_solid)){ x += 3 * sign(image_xscale) * global.delta; }
-        maxspd = 3; 
+    else if(sprite_index == spr_player_roll &amp;&amp; hspd == 0 &amp;&amp; direction_horizontal == 0 &amp;&amp; image_index &lt;= image_number-1){
+        if(!place_meeting(x+4, y, obj_solid) &amp;&amp; !place_meeting(x+3, y, obj_solid) &amp;&amp; !place_meeting(x+2, y, obj_solid) &amp;&amp; !place_meeting(x+1, y, obj_solid)){ x += 3 * sign(image_xscale) * global.delta; }
         is_rolling = 1;
+        maxspd = 3; 
     }
-    
 
 
     

--- a/Project2.gmx/scripts/scr_player_move_state.gml
+++ b/Project2.gmx/scripts/scr_player_move_state.gml
@@ -6,8 +6,9 @@
 
 //Horizontal Movement
     
-    if(direction_vertical == 1 && hspd != 0 && place_meeting(x, y+16, obj_solid)){
-        hspd = max(abs(hspd) - ((acc*.25)*global.delta), 0) * sign(hspd); 
+    //Slide if we have horizontal speed but are holding down. 
+    if(is_sliding == 1){
+        hspd = max(abs(hspd) - ((acc*.25)*global.delta), 0) * sign(hspd);   
     }
     //We check to see if we are attempting to change direction, or if we stop giving input. If so, slow down. 
     else if(direction_horizontal == 0 || (hspd > 0 && direction_horizontal == -1) || (hspd < 0 && direction_horizontal == 1)){ 

--- a/Project2.gmx/scripts/scr_player_move_state.gml
+++ b/Project2.gmx/scripts/scr_player_move_state.gml
@@ -114,7 +114,7 @@
     if (hspd != 0) {
         image_xscale = sign(hspd);
     }
-
+    
 scr_move(obj_solid);
 
 

--- a/Project2.gmx/sprites/spr_player_roll.sprite.gmx
+++ b/Project2.gmx/sprites/spr_player_roll.sprite.gmx
@@ -8,7 +8,7 @@
   <sepmasks>0</sepmasks>
   <bboxmode>2</bboxmode>
   <bbox_left>6</bbox_left>
-  <bbox_right>26</bbox_right>
+  <bbox_right>30</bbox_right>
   <bbox_top>9</bbox_top>
   <bbox_bottom>30</bbox_bottom>
   <HTile>0</HTile>

--- a/Project2.gmx/sprites/spr_player_slide.sprite.gmx
+++ b/Project2.gmx/sprites/spr_player_slide.sprite.gmx
@@ -8,7 +8,7 @@
   <sepmasks>0</sepmasks>
   <bboxmode>2</bboxmode>
   <bbox_left>6</bbox_left>
-  <bbox_right>30</bbox_right>
+  <bbox_right>26</bbox_right>
   <bbox_top>9</bbox_top>
   <bbox_bottom>30</bbox_bottom>
   <HTile>0</HTile>


### PR DESCRIPTION
- Fixed 4 rolling when crouching and tapping a direction. 

- Updated the roll to move 3 pixels in the direction of image_xscale if the roll hasn't finished its animation, but the player has let go of a horizontal direction. 

- Updated the horizontal movement animation so that if the player jumps, holds down, and then moves horizontally without letting go of down, the running animation still plays. 