### PR TITLE
0037 - Dash Charge Fixes

### DIFF
--- a/Project2.gmx/objects/obj_debugtext.object.gmx
+++ b/Project2.gmx/objects/obj_debugtext.object.gmx
@@ -135,6 +135,14 @@ draw_text(10, 404, "dash_held: "+string_format(obj_player.dash_distance_mod, 2, 
     if (obj_player.dash_distance_mod &gt;= 5) {
         draw_rectangle_colour(view_wport[0]-40, 20, view_wport[0]-20, 60, c_green, c_green, c_green, c_green, false);
     }
+    if (obj_player.dash_held_frames &gt;= 155 &amp;&amp; obj_player.dash_held_frames &lt;= 170) {
+        draw_set_colour(c_red);
+        draw_rectangle(view_wport[0]-150, 25, view_wport[0]-145, 45, false);
+        draw_rectangle(view_wport[0]-150, 50, view_wport[0]-145, 55, false);
+        draw_set_colour(c_gray);
+        draw_rectangle(view_wport[0]-150, 25, view_wport[0]-145, 45, true);
+        draw_rectangle(view_wport[0]-150, 50, view_wport[0]-145, 55, true);
+    }
     draw_set_colour(c_gray);
     draw_rectangle(view_wport[0]-120, 20, view_wport[0]-19, 60, true);
     draw_rectangle(view_wport[0]-119, 21, view_wport[0]-20, 59, true);

--- a/Project2.gmx/objects/obj_player.object.gmx
+++ b/Project2.gmx/objects/obj_player.object.gmx
@@ -86,7 +86,9 @@
     dash = false;
     dash_held = false;
     dash_released = false;
-    switch_dash_mode = false;
+    charge_dash = false;
+    charge_dash_held = false;
+    charge_dash_released = false;
     
     diag_ul = false;
     diag_ul_held = false;

--- a/Project2.gmx/scripts/scr_get_input.gml
+++ b/Project2.gmx/scripts/scr_get_input.gml
@@ -23,7 +23,9 @@ sprint = keyboard_check(vk_shift);
 dash = keyboard_check_pressed(ord("F"));
 dash_held = keyboard_check(ord("F"));
 dash_released = keyboard_check_released(ord("F"));
-switch_dash_mode = keyboard_check_pressed(ord("G"));
+charge_dash = keyboard_check_pressed(ord("G"));
+charge_dash_held = keyboard_check(ord("G"));
+charge_dash_released = keyboard_check_released(ord("G"));
 
 // Override the controls for a gamepad
 gp_id = 0;
@@ -69,10 +71,12 @@ if (gamepad_is_connected(gp_id)) {
     
     // Set inputs
     sprint = gamepad_button_check(gp_id, gp_shoulderrb);
-    dash = gamepad_button_check_pressed(gp_id, gp_shoulderlb) || gamepad_button_check_pressed(gp_id, gp_shoulderl);
-    dash_held = gamepad_button_check(gp_id, gp_shoulderlb) || gamepad_button_check(gp_id, gp_shoulderl);
-    dash_released = gamepad_button_check_released(gp_id, gp_shoulderlb) || gamepad_button_check_released(gp_id, gp_shoulderl);
-    switch_dash_mode = gamepad_button_check_pressed(gp_id, gp_face3);
+    dash = gamepad_button_check_pressed(gp_id, gp_shoulderl);
+    dash_held = gamepad_button_check(gp_id, gp_shoulderl);
+    dash_released = gamepad_button_check_released(gp_id, gp_shoulderl);
+    charge_dash = gamepad_button_check_pressed(gp_id, gp_shoulderlb);
+    charge_dash_held = gamepad_button_check(gp_id, gp_shoulderlb);
+    charge_dash_released = gamepad_button_check_released(gp_id, gp_shoulderlb);
     
     up = gamepad_button_check_pressed(gp_id, gp_face1);
     up_held = gamepad_button_check(gp_id, gp_face1);

--- a/Project2.gmx/scripts/scr_player_move_state.gml
+++ b/Project2.gmx/scripts/scr_player_move_state.gml
@@ -118,19 +118,9 @@
     }
     
 // Dash Mode
-    if (switch_dash_mode) {
+    if (charge_dash) {
         // Switch modes
-        if (dash_charge_mode) {
-            dash_charge_mode = false;
-        } else {
-            dash_charge_mode = true;
-        }
-    }
-    // Set the correct button input depending on the dash mode
-    if (dash_charge_mode) {
-        dash_activate = dash_released;
-    } else {
-        dash_activate = dash;
+        dash_charge_mode = true;
     }
     
 // Mid-Air Dashing
@@ -175,7 +165,7 @@
                 // Not dashing at all
                 if (dash_count < 3) {
                     // Can dash again
-                    if (dash_activate && (right_held || (diag_ur_held && abs(x_axis) >= abs(y_axis)) || (diag_dr_held && abs(x_axis) >= abs(y_axis)))) {
+                    if (((charge_dash_released || dash) && !(charge_dash_released && dash)) && (right_held || (diag_ur_held && abs(x_axis) >= abs(y_axis)) || (diag_dr_held && abs(x_axis) >= abs(y_axis)))) {
                         // Wants to dash right
                         if (dash_charge_mode) {
                             // Charge Dash
@@ -192,8 +182,9 @@
                             hspd = dash_speed;
                             vspd = 0;
                             dashed = true;
+                            dash_charge_mode = false;
                         }
-                    } else if (dash_activate && (left_held || (diag_ul_held && abs(x_axis) >= abs(y_axis)) || (diag_dl_held && abs(x_axis) >= abs(y_axis)))) {
+                    } else if (((charge_dash_released || dash) && !(charge_dash_released && dash)) && (left_held || (diag_ul_held && abs(x_axis) >= abs(y_axis)) || (diag_dl_held && abs(x_axis) >= abs(y_axis)))) {
                         // Wants to dash left
                         if (dash_charge_mode) {
                             // Charge Dash
@@ -210,8 +201,9 @@
                             hspd = -dash_speed;
                             vspd = 0;
                             dashed = true;
+                            dash_charge_mode = false;
                         }
-                    } else if (dash_activate && ((up_held && !gamepad_is_connected(0)) || (stick_up_held && gamepad_is_connected(0)) || (diag_ul_held && abs(y_axis) > abs(x_axis)) || (diag_ur_held && abs(y_axis) > abs(x_axis)))) {
+                    } else if (((charge_dash_released || dash) && !(charge_dash_released && dash)) && ((up_held && !gamepad_is_connected(0)) || (stick_up_held && gamepad_is_connected(0)) || (diag_ul_held && abs(y_axis) > abs(x_axis)) || (diag_ur_held && abs(y_axis) > abs(x_axis)))) {
                         // Wants to dash up
                         if (dash_charge_mode) {
                             // Charge Dash
@@ -228,6 +220,7 @@
                             vspd = -dash_speed * .6;
                             hspd = 0;
                             dashed = true;
+                            dash_charge_mode = false;
                         }
                     } else {
                         // Isnt dashing and doesnt want to dash
@@ -247,7 +240,7 @@
         if (can_dash) {
             // In mid-air
             if (dash_count < 3) {
-                if (dash_held) {
+                if (charge_dash_held) {
                     // Charge the dash
                     if (dash_held_frames <= 75) {
                         dash_held_frames += 1;
@@ -255,11 +248,12 @@
                     dash_distance_mod = dash_held_frames div 15;
                     vspd = 0;
                     hspd = 0;
-                } else if (dash_released) {
+                } else if (charge_dash_released) {
                     // Reset the charge for the next dash
                     dash_held_frames = 0;
                     dash_distance_mod = 0;
                     dash_count += 1;
+                    dash_charge_mode = false;
                 }
             }
         }

--- a/Project2.gmx/scripts/scr_player_move_state.gml
+++ b/Project2.gmx/scripts/scr_player_move_state.gml
@@ -54,6 +54,9 @@
         can_dash = false;
         dashed = false;
         jumppeak = 0;
+        dash_held_frames = 0;
+        dash_distance_mod = 0;
+        dash_charge_mode = false;
     } else {
         can_dash = true;
     }
@@ -242,12 +245,12 @@
             if (dash_count < 3) {
                 if (charge_dash_held) {
                     // Charge the dash
-                    if (dash_held_frames <= 75) {
+                    if (dash_held_frames <= 150) {
                         dash_held_frames += 1;
                     }
-                    dash_distance_mod = dash_held_frames div 15;
-                    vspd = 0;
-                    hspd = 0;
+                    dash_distance_mod = dash_held_frames div 30;
+                    vspd /= 6;
+                    hspd /= 1.75;
                 } else if (charge_dash_released) {
                     // Reset the charge for the next dash
                     dash_held_frames = 0;

--- a/Project2.gmx/scripts/scr_player_move_state.gml
+++ b/Project2.gmx/scripts/scr_player_move_state.gml
@@ -168,7 +168,7 @@
                 // Not dashing at all
                 if (dash_count < 3) {
                     // Can dash again
-                    if (((charge_dash_released || dash) && !(charge_dash_released && dash)) && (right_held || (diag_ur_held && abs(x_axis) >= abs(y_axis)) || (diag_dr_held && abs(x_axis) >= abs(y_axis)))) {
+                    if ((((charge_dash_released && dash_charge_mode) || dash) && !(charge_dash_released && dash)) && (right_held || (diag_ur_held && abs(x_axis) >= abs(y_axis)) || (diag_dr_held && abs(x_axis) >= abs(y_axis)))) {
                         // Wants to dash right
                         if (dash_charge_mode) {
                             // Charge Dash
@@ -187,7 +187,7 @@
                             dashed = true;
                             dash_charge_mode = false;
                         }
-                    } else if (((charge_dash_released || dash) && !(charge_dash_released && dash)) && (left_held || (diag_ul_held && abs(x_axis) >= abs(y_axis)) || (diag_dl_held && abs(x_axis) >= abs(y_axis)))) {
+                    } else if ((((charge_dash_released && dash_charge_mode) || dash) && !(charge_dash_released && dash)) && (left_held || (diag_ul_held && abs(x_axis) >= abs(y_axis)) || (diag_dl_held && abs(x_axis) >= abs(y_axis)))) {
                         // Wants to dash left
                         if (dash_charge_mode) {
                             // Charge Dash
@@ -206,7 +206,7 @@
                             dashed = true;
                             dash_charge_mode = false;
                         }
-                    } else if (((charge_dash_released || dash) && !(charge_dash_released && dash)) && ((up_held && !gamepad_is_connected(0)) || (stick_up_held && gamepad_is_connected(0)) || (diag_ul_held && abs(y_axis) > abs(x_axis)) || (diag_ur_held && abs(y_axis) > abs(x_axis)))) {
+                    } else if ((((charge_dash_released && dash_charge_mode) || dash) && !(charge_dash_released && dash)) && ((up_held && !gamepad_is_connected(0)) || (stick_up_held && gamepad_is_connected(0)) || (diag_ul_held && abs(y_axis) > abs(x_axis)) || (diag_ur_held && abs(y_axis) > abs(x_axis)))) {
                         // Wants to dash up
                         if (dash_charge_mode) {
                             // Charge Dash
@@ -245,12 +245,12 @@
             if (dash_count < 3) {
                 if (charge_dash_held) {
                     // Charge the dash
-                    if (dash_held_frames <= 150) {
+                    if (dash_held_frames <= 179) {
                         dash_held_frames += 1;
+                        dash_distance_mod = dash_held_frames div 30;
+                        vspd /= 6;
+                        hspd /= 1.75;
                     }
-                    dash_distance_mod = dash_held_frames div 30;
-                    vspd /= 6;
-                    hspd /= 1.75;
                 } else if (charge_dash_released) {
                     // Reset the charge for the next dash
                     dash_held_frames = 0;


### PR DESCRIPTION
- Removed dash modes. Player can now use both dashes without pressing a button.
- Removed the completely still charge hovering. The player now moves slowly.
- Slowed the charge time by half.
- Added a fall after the charge hits full strength.