### PR TITLE
0048 - Fullscreen with Vsync, Room-Dependent Screenshake, and Platform Sprite Tiling

### DIFF
--- a/Project2.gmx/objects/obj_blur.object.gmx
+++ b/Project2.gmx/objects/obj_blur.object.gmx
@@ -66,7 +66,7 @@ dif_Y = cam_last_Y-view_yview[0];
 
 //Copyroutine
 surface_set_target(temp); //This part moves the trail in camera
-if(temp){
+if(surface_exists(temp)){
     draw_surface_ext(global.motion_blur,dif_X,dif_Y,1,1,0,c_white,0.94); 
     surface_copy(global.motion_blur,0,0,temp);
 }
@@ -101,8 +101,9 @@ cam_last_Y = view_yview[0];
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>draw_surface_ext(global.motion_blur,view_xview[0],view_yview[0],1,1,0,c_white,0.8);
-
+            <string>if(surface_exists(global.motion_blur)){
+    draw_surface_ext(global.motion_blur,view_xview[0],view_yview[0],1,1,0,c_white,0.8);
+}
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_dynamic_camera.object.gmx
+++ b/Project2.gmx/objects/obj_dynamic_camera.object.gmx
@@ -2,7 +2,7 @@
 <object>
   <spriteName>&lt;undefined&gt;</spriteName>
   <solid>0</solid>
-  <visible>-1</visible>
+  <visible>0</visible>
   <depth>-10</depth>
   <persistent>-1</persistent>
   <parentName>&lt;undefined&gt;</parentName>
@@ -86,11 +86,13 @@ y += (y_to-y)/2;
 view_xview = -(view_wview/2) + x; 
 view_yview = -(view_hview/2) + y;   
 
-view_xview += random_range(-shake*(view_wview/100), shake*(view_wview/500));
-view_yview += random_range(-shake*(view_hview/100), shake*(view_wview/500)); 
-
 view_xview = clamp(view_xview, 0, room_width-view_wview);
 view_yview = clamp(view_yview, 0, room_height-view_hview); 
+
+view_xview += random_range(-shake*(view_wview/500), shake*(view_wview/500));
+view_yview += random_range(-shake*(view_hview/500), shake*(view_wview/500)); 
+
+
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_dynamic_camera.object.gmx
+++ b/Project2.gmx/objects/obj_dynamic_camera.object.gmx
@@ -28,6 +28,7 @@
             <string>///Initialize camera variables
 
 shake = 0; 
+full_screen = false; 
 </string>
           </argument>
         </arguments>
@@ -71,7 +72,11 @@ if(instance_exists(obj_player)){
     }
 }
 
+if(keyboard_check_pressed(vk_f2)){
+    full_screen = !full_screen;
+    window_set_fullscreen(full_screen); 
 
+}
 
 x_to = obj_player.x + obj_player.direction_horizontal*abs(obj_player.hspd);
 y_to = obj_player.y + obj_player.direction_vertical*abs(obj_player.vspd);
@@ -81,12 +86,11 @@ y += (y_to-y)/2;
 view_xview = -(view_wview/2) + x; 
 view_yview = -(view_hview/2) + y;   
 
-view_xview = clamp(view_xview, 0, room_width-view_wview);
-view_yview = clamp(view_yview, 0, room_height-view_hview); 
-
 view_xview += random_range(-shake*(view_wview/100), shake*(view_wview/500));
 view_yview += random_range(-shake*(view_hview/100), shake*(view_wview/500)); 
 
+view_xview = clamp(view_xview, 0, room_width-view_wview);
+view_yview = clamp(view_yview, 0, room_height-view_hview); 
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_dynamic_camera.object.gmx
+++ b/Project2.gmx/objects/obj_dynamic_camera.object.gmx
@@ -29,6 +29,7 @@
 
 shake = 0; 
 full_screen = false; 
+display_reset(0, true); 
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_platform.object.gmx
+++ b/Project2.gmx/objects/obj_platform.object.gmx
@@ -28,10 +28,49 @@
             <string>if(instance_exists(obj_player)){
     if(obj_player.vspd &gt; 0 &amp;&amp; !place_meeting(x, y, obj_player)){
     
-        platform = instance_create(x, y, obj_platform_solid); 
+        platform = instance_create(x, y, obj_platform_solid);
+        platform.image_xscale = image_xscale;
+        platform.image_yscale = image_yscale;   
         instance_destroy(); 
     }
 }
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="8" enumb="0">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///Tile sprite across surface
+
+s_width = sprite_get_width(spr_platform);   //Width of the sprite in pixels.
+s_height = sprite_get_height(spr_platform); //Height of the sprite in pixels. 
+
+offset_x =  s_width * image_xscale/2 - s_width/2;   //Offset is in pixels from origin of object, subtract width/2 to compensate for drawing from origin.
+offset_y =  s_height * image_yscale/2 - s_height/2; //Offset is in pixels from origin of object, subtract height/2 to compensate for drawing from origin. 
+
+//tiles sprites across the width and height of the object. Only works for scales of whole numbers. 
+for(index_x = 0; index_x &lt; image_xscale * s_width; index_x += s_width){
+    for(index_y = 0; index_y &lt; image_yscale * s_height; index_y += s_height){
+        draw_sprite(spr_platform, 0, x-offset_x+index_x, y-offset_y+index_y); 
+    }
+}
+
 </string>
           </argument>
         </arguments>

--- a/Project2.gmx/objects/obj_platform_solid.object.gmx
+++ b/Project2.gmx/objects/obj_platform_solid.object.gmx
@@ -28,8 +28,46 @@
             <string>if(instance_exists(obj_player)){
     if(obj_player.vspd &lt; 0 || place_meeting(x, y, obj_player)){
     
-        platform = instance_create(x, y, obj_platform); 
+        platform = instance_create(x, y, obj_platform);
+        platform.image_xscale = image_xscale;
+        platform.image_yscale = image_yscale;  
         instance_destroy(); 
+    }
+}
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="8" enumb="0">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///Tile sprite across surface
+
+s_width = sprite_get_width(spr_platform);   //Width of the sprite in pixels.
+s_height = sprite_get_height(spr_platform); //Height of the sprite in pixels. 
+
+offset_x =  s_width * image_xscale/2 - s_width/2;   //Offset is in pixels from origin of object, subtract width/2 to compensate for drawing from origin.
+offset_y =  s_height * image_yscale/2 - s_height/2; //Offset is in pixels from origin of object, subtract height/2 to compensate for drawing from origin. 
+
+//tiles sprites across the width and height of the object. Only works for scales of whole numbers. 
+for(index_x = 0; index_x &lt; image_xscale * s_width; index_x += s_width){
+    for(index_y = 0; index_y &lt; image_yscale * s_height; index_y += s_height){
+        draw_sprite(spr_platform, 0, x-offset_x+index_x, y-offset_y+index_y); 
     }
 }
 </string>

--- a/Project2.gmx/objects/obj_player.object.gmx
+++ b/Project2.gmx/objects/obj_player.object.gmx
@@ -222,7 +222,9 @@ script_execute(state);
     //Switches to idle if hspd and vspd are 0 and the player is in the running animation
     //Reset the max speed to normal, in case the player was rolling. 
     if(hspd == 0 &amp;&amp; vspd == 0 &amp;&amp; ( sprite_index == spr_fahad_player_test_1 
-       || (sprite_index == spr_player_slide_to_crouch &amp;&amp; !down_held &amp;&amp; !down &amp;&amp; !diag_dl &amp;&amp; !diag_dr &amp;&amp; !place_meeting(x, y-8, obj_solid)))
+       || ((sprite_index == spr_player_slide_to_crouch &amp;&amp; !down_held &amp;&amp; !down &amp;&amp; !diag_dl &amp;&amp; !diag_dr)
+       &amp;&amp; !place_meeting(x, y-8, obj_solid))
+       )
       ){ 
         sprite_index = spr_player_idle; 
         maxspd = 8; 
@@ -232,7 +234,7 @@ script_execute(state);
     }
     //Switches to running if we have any hspd but aren't jumping/falling.
     //Reset max speed to normal, in case the player was previously rolling.
-    else if(hspd != 0 &amp;&amp; vspd == 0 &amp;&amp; !diag_dl_held &amp;&amp; !diag_dr_held 
+    else if(hspd != 0 &amp;&amp; vspd == 0 &amp;&amp; !diag_dl_held &amp;&amp; !diag_dr_held
             &amp;&amp; (sprite_index == spr_player_idle || sprite_index == spr_fahad_player_test_1 || sprite_index == spr_player_wall_slide)
            ){
         sprite_index = spr_fahad_player_test_1; 
@@ -334,7 +336,7 @@ script_execute(state);
 //Crouching Animation
 
     //Switches to the crouching animation if the player presses down, isn't moving, and hasn't already been switched.
-    if((down || down_held || diag_dl_held || diag_dr_held || place_meeting(x, y-8, obj_solid)) 
+    if((down || down_held || diag_dl_held || diag_dr_held /*|| place_meeting(x, y-8, obj_solid)*/) 
     &amp;&amp; place_meeting(x, y+1, obj_solid) &amp;&amp; hspd == 0 &amp;&amp; sprite_index != spr_player_crouch 
         &amp;&amp; sprite_index != spr_player_roll &amp;&amp; sprite_index != spr_player_slide &amp;&amp; sprite_index != spr_player_slide_to_crouch 
       ){

--- a/Project2.gmx/rooms/rm_one.room.gmx
+++ b/Project2.gmx/rooms/rm_one.room.gmx
@@ -113,27 +113,14 @@
     <instance objName="obj_solid" x="544" y="352" name="inst_EFEE2372" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_solid" x="576" y="352" name="inst_4BF467A2" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_next_room" x="576" y="320" name="inst_225D2086" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="192" y="256" name="inst_26D12CB0" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="224" y="256" name="inst_1DDF73D9" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="256" y="256" name="inst_ACF7A9C8" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="288" y="256" name="inst_70BA0D00" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="320" y="256" name="inst_3203DA1D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="320" y="192" name="inst_B045C37D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="352" y="192" name="inst_D0148996" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="384" y="192" name="inst_720A61D9" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="448" y="192" name="inst_21C837D9" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="416" y="192" name="inst_E9692D81" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="448" y="128" name="inst_BC7920EF" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="480" y="128" name="inst_AC18BC6F" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="512" y="128" name="inst_97846678" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="544" y="128" name="inst_C13FEC82" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="576" y="128" name="inst_59E352F2" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_solid" x="335" y="232" name="inst_89F39A7D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_solid" x="367" y="295" name="inst_DA6EF567" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_solid" x="400" y="295" name="inst_D344E0CE" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_dynamic_camera" x="40" y="41" name="inst_13382018" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="&lt;undefined&gt;" x="0" y="0" name="inst_8DA8151D" locked="0" code="" scaleX="0" scaleY="0" colour="0" rotation="0"/>
     <instance objName="&lt;undefined&gt;" x="0" y="0" name="inst_6007D190" locked="0" code="" scaleX="0" scaleY="0" colour="0" rotation="0"/>
+    <instance objName="obj_platform" x="256" y="288" name="inst_6D9CCE18" locked="0" code="" scaleX="10" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="96" y="288" name="inst_F4F773D2" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="384" y="288" name="inst_95C3D22C" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="256" y="288" name="inst_B9D98D5F" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="224" y="288" name="inst_359113E5" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>

--- a/Project2.gmx/rooms/rm_one.room.gmx
+++ b/Project2.gmx/rooms/rm_one.room.gmx
@@ -118,7 +118,6 @@
     <instance objName="obj_platform_solid" x="256" y="256" name="inst_ACF7A9C8" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="288" y="256" name="inst_70BA0D00" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="320" y="256" name="inst_3203DA1D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_platform_solid" x="352" y="256" name="inst_3DF5C9F8" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="320" y="192" name="inst_B045C37D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="352" y="192" name="inst_D0148996" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="384" y="192" name="inst_720A61D9" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
@@ -129,10 +128,12 @@
     <instance objName="obj_platform_solid" x="512" y="128" name="inst_97846678" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="544" y="128" name="inst_C13FEC82" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_platform_solid" x="576" y="128" name="inst_59E352F2" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_solid" x="352" y="295" name="inst_89F39A7D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_solid" x="384" y="295" name="inst_DA6EF567" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_solid" x="416" y="295" name="inst_D344E0CE" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="335" y="232" name="inst_89F39A7D" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="367" y="295" name="inst_DA6EF567" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_solid" x="400" y="295" name="inst_D344E0CE" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_dynamic_camera" x="40" y="41" name="inst_13382018" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="&lt;undefined&gt;" x="0" y="0" name="inst_8DA8151D" locked="0" code="" scaleX="0" scaleY="0" colour="0" rotation="0"/>
+    <instance objName="&lt;undefined&gt;" x="0" y="0" name="inst_6007D190" locked="0" code="" scaleX="0" scaleY="0" colour="0" rotation="0"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>


### PR DESCRIPTION
 - Added a fullscreen mode, press F2 to fullscreen.
 - Cameras automatically enable vsync, plan on adding options menu later
 - Toned down screen shake, and made the shake factor in room size so shake looks consistent across rooms. 
 - Added tiling to stretched platforms. Stretched platforms avoid collision issues with adjacent platforms. However, additional code was needed to make the platform's sprite's tile across its width and height. It only works for whole number image scales. 
 - Refactored some animation code to make it more robust. Fixed issues of rapid crouch-uncrouching when there is only a pixel of headroom. 